### PR TITLE
Implemented CRC / Multiple battery support

### DIFF
--- a/BMS/BMS.ino
+++ b/BMS/BMS.ino
@@ -28,7 +28,7 @@
 #define enablePin 17
 
 // Set slave numbers for batteries you want to communicate
-byte batteries[1] = {0x01};
+byte batteries[] = {0x01};
 // Set BMS thresholds - mV and C
 unsigned int battHighV = 3600;
 unsigned int battLowV = 3000;

--- a/BMS/BMS.ino
+++ b/BMS/BMS.ino
@@ -17,7 +17,6 @@
 #include <Arduino.h> // required before wiring_private.h
 #include <Adafruit_NeoPixel.h>
 #include <SD.h>
-#include <Crc16.h>
 #include "wiring_private.h" // pinPeripheral() function
 
 // Set digital out pin numbers for relays. r1 is the battery disconnect and r2 is a pv array disconnect.


### PR DESCRIPTION
OpenXPBMS now implements CRC, which allows for support for multiple batteries. the HEX value of each battery ID should be added to the batteries byte array before uploading the sketch to the board.